### PR TITLE
Fix advancement and settings bugs

### DIFF
--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,31 +1,5 @@
-**New Features**
-- A new world setting, Disable Multiclassing, lets GMs prevent players from adding a second class. When enabled, the add-class UI is hidden during character creation and multiclass options are removed on level-up.
-- A new world setting, Disable Welcome Popup, lets GMs suppress the welcome dialog for every player in the world, overriding each player's own Show Welcome setting.
-- A new world setting, Publish HP Rolls (on by default), posts each manual hit-die roll to chat, flavored with the rolling character's class and level.
-- Background options in the identity dropdown now show searchable pills for their ability score increase and origin feat, and skip non-improvable abilities like Honor and Sanity.
-- Brazilian Portuguese (pt-BR) is now available as a module language.
-- The Exclusion List now has a Feats tab so GMs can exclude specific feats; excluded feats are dropped from the feat picker.
-- The feat browser has a new Ability increase filter so you can narrow feats down to those whose ability score increase can raise a chosen ability.
-
 **Bug Fixes**
-- Advancements that come with a granted feat, including any choices they ask for, now apply during the same level up instead of being skipped.
-- Changing a class in one of your roster slots now clears that slot's subclass and advancement picks so they cannot stay mismatched, while your other multiclass slots are left untouched and saved drafts keep their picks on restore.
-- Combobox pills are now trimmed responsively so the identity label is never clipped when an option carries many tags.
-- Currency bundled into a class or background equipment package that is always granted (not behind an either/or choice) is now added to your starting gold pool.
-- Equipment choices that grant more than one pick now show a separate slot for each pick, so you can choose the same option in multiple slots.
-- Feat choices in advancement steps now only show feats your character qualifies for at that level, matching the core dnd5e level requirement.
-- Feats granted by an Ability Score Improvement choice are now actually added to your character on level up.
-- Newly created characters now show correct walk speed instead of 0, with movement, senses, and creature type derived properly from their race.
-- Optional abilities such as Honor and Sanity are now handled correctly: the standard array sizes to your full ability count so the randomizer assigns every ability, and the Ability Score Improvement grid hides abilities that cannot be improved.
-- Skill Expertise choices during character creation now only offer skills you are already proficient in, drawn from the proficiencies you picked earlier in the same draft.
-- The Browse button in the Art Directory setting now opens the file picker as expected.
-- The Finalize tab proficiency review now lists the skills, tools, and languages you picked during advancement steps, not just the ones granted automatically.
-- The Level Up button no longer piles up into duplicates on character and group sheets each time the sheet re-renders.
-- The level-up portrait now crops from the top so the character's head stays visible instead of being cut off in short frames.
-
-**Changes**
-- Expertise picks now sort after the proficiency choices they depend on, so you select your proficiencies before being asked which to make expert.
-- Players choosing their character art are now locked to the GM-configured art folder, while GMs can still browse anywhere.
-- The Publish Level-Up Summary whisper option is now labeled "Whisper GM + Owner" to make clear the summary goes to the GM and the character's owners.
-
-Full changelog: https://github.com/Sayshal/hero-mancer/releases
+- Point Buy now seeds each ability score at the configured default value instead of starting blank, with cost, points used, and modifier derived from that default. Standard Array and Manual Formula stay blank.
+- Race advancement choices that require the character's own race, such as the Dragonborn Draconic Ancestry breath weapon, now list their valid options instead of showing "No valid options".
+- Tiered item-choice options that require a base option first, such as Grim Hollow heritage traits where Maximum Critical requires Awesome Critical, now appear in the picker the moment you select the base option and cascade-remove when you unselect it, instead of staying hidden until the picker is closed and reopened.
+- Untyped "choose any item" advancement choices that allow drops, such as Grim Hollow's Rare Find on the Agent of the Augustine background, now open a compendium browser of grantable item types instead of showing "No valid options".

--- a/scripts/apps/hero-mancer.mjs
+++ b/scripts/apps/hero-mancer.mjs
@@ -2968,7 +2968,8 @@ export class HeroMancer extends HMDialog {
       ui.notifications.warn('HEROMANCER.App.Advancements.BrowseMax', { localize: true });
       return;
     }
-    const filters = { locked: { additional: {}, documentClass: 'Item', types: new Set([cfg.type]) } };
+    const filters = { locked: { additional: {}, documentClass: 'Item' } };
+    filters.locked.types = cfg.type ? new Set([cfg.type]) : CONFIG.DND5E.advancementTypes.ItemChoice.documentClass.VALID_TYPES;
     switch (cfg.type) {
       case 'spell':
         if (cfg.level !== '') filters.locked.additional.level = cfg.level === 'available' ? { max: cfg.maxSpellLevel } : { min: Number(cfg.level), max: Number(cfg.level) };

--- a/scripts/components/equipment-detail-panel.mjs
+++ b/scripts/components/equipment-detail-panel.mjs
@@ -129,15 +129,23 @@ export class EquipmentDetailPanel {
       options = [];
     }
     const max = Math.max(1, Number(trig.dataset.pickerMax) || 1);
+    let origins = null;
+    try {
+      origins = trig.dataset.pickerOrigins ? new Set(JSON.parse(trig.dataset.pickerOrigins)) : null;
+    } catch {
+      origins = null;
+    }
     this.activeName = name;
     this.activeTrigger = trig;
     this.activeOptions = options;
     this.activeMax = max;
     this.activeLabel = trig.dataset.pickerLabel ?? '';
+    this.activeOrigins = origins;
     const currentValues = max > 1 ? (input.value ? input.value.split(',').filter(Boolean) : []) : input.value;
     this.#refreshMultiTitle(Array.isArray(currentValues) ? currentValues.length : 0);
     this.searchInput.value = '';
     this.#renderOptions(options, currentValues);
+    this.#filter();
     if (max > 1) this.#applyMultiCapacityState(Array.isArray(currentValues) ? currentValues.length : 0);
     this.root.hidden = false;
     requestAnimationFrame(() => this.root.classList.add('is-open'));
@@ -262,14 +270,15 @@ export class EquipmentDetailPanel {
     applyItemLinks(this.list);
   }
 
-  /** Filter rendered options by the search input value. */
+  /** Filter rendered options by the search input value, hiding options gated by an unmet prerequisite. */
   #filter() {
     const q = this.searchInput.value.trim().toLowerCase();
+    const gated = this.#gatedValues();
     let visible = 0;
     for (const btn of this.list.querySelectorAll('[data-detail-option]')) {
-      const match = !q || btn.dataset.label.includes(q);
-      btn.parentElement.hidden = !match;
-      if (match) visible++;
+      const show = (!q || btn.dataset.label.includes(q)) && !gated.has(btn.dataset.value);
+      btn.parentElement.hidden = !show;
+      if (show) visible++;
     }
     this.emptyEl.hidden = visible > 0;
   }
@@ -301,22 +310,20 @@ export class EquipmentDetailPanel {
       this.close();
       return;
     }
-    const current = new Set(input.value ? input.value.split(',').filter(Boolean) : []);
+    let current = new Set(input.value ? input.value.split(',').filter(Boolean) : []);
     if (current.has(value)) current.delete(value);
     else {
       if (current.size >= max) return;
       current.add(value);
     }
+    current = this.#pruneSelection(current);
     input.value = [...current].join(',');
     input.dispatchEvent(new Event('change', { bubbles: true }));
-    const btn = this.list.querySelector(`[data-detail-option][data-value="${CSS.escape(value)}"]`);
-    if (btn) {
-      btn.toggleAttribute('data-selected', current.has(value));
-      btn.setAttribute('aria-selected', current.has(value) ? 'true' : 'false');
-    }
+    this.#syncSelectedButtons(current);
     this.#refreshMultiTitle(current.size);
     this.#applyMultiCapacityState(current.size);
     this.#updateMultiTriggerLabel([...current]);
+    if (this.activeOrigins) this.#filter();
   }
 
   /**
@@ -452,5 +459,63 @@ export class EquipmentDetailPanel {
     this.activeSections = null;
     this.activeMax = null;
     this.activeLabel = null;
+    this.activeOrigins = null;
+  }
+
+  /**
+   * Drop selected options whose item prerequisite is no longer met, cascading through dependent tiers.
+   * @param {Set<string>} selected Currently-selected option values.
+   * @returns {Set<string>} The pruned selection.
+   */
+  #pruneSelection(selected) {
+    if (!this.activeOrigins) return selected;
+    const metaByValue = new Map((this.activeOptions ?? []).map((o) => [o.value, o]));
+    const set = new Set(selected);
+    for (let changed = true; changed; ) {
+      changed = false;
+      const available = new Set(this.activeOrigins);
+      for (const v of set) {
+        const id = metaByValue.get(v)?.identifier;
+        if (id) available.add(id);
+      }
+      for (const v of [...set]) {
+        const req = metaByValue.get(v)?.reqItems ?? [];
+        if (req.length && !req.some((id) => available.has(id))) {
+          set.delete(v);
+          changed = true;
+        }
+      }
+    }
+    return set;
+  }
+
+  /**
+   * Reflect a selection set onto every option button's selected state.
+   * @param {Set<string>} selected Selected option values.
+   */
+  #syncSelectedButtons(selected) {
+    for (const btn of this.list.querySelectorAll('[data-detail-option]')) {
+      const on = selected.has(btn.dataset.value);
+      btn.toggleAttribute('data-selected', on);
+      btn.setAttribute('aria-selected', on ? 'true' : 'false');
+    }
+  }
+
+  /**
+   * Option values to hide because their item prerequisite is unmet by the current live selection.
+   * @returns {Set<string>} Gated values; empty unless the active picker carries prerequisite metadata.
+   */
+  #gatedValues() {
+    const gated = new Set();
+    if (!this.activeOrigins || !this.activeName) return gated;
+    const input = this.scope.querySelector(`input[type="hidden"][name="${CSS.escape(this.activeName)}"]`);
+    const selected = new Set(input?.value ? input.value.split(',').filter(Boolean) : []);
+    const available = new Set(this.activeOrigins);
+    for (const opt of this.activeOptions ?? []) if (selected.has(opt.value) && opt.identifier) available.add(opt.identifier);
+    for (const opt of this.activeOptions ?? []) {
+      if (selected.has(opt.value)) continue;
+      if (opt.reqItems?.length && !opt.reqItems.some((id) => available.has(id))) gated.add(opt.value);
+    }
+    return gated;
   }
 }

--- a/scripts/domain/ability-scores.mjs
+++ b/scripts/domain/ability-scores.mjs
@@ -139,8 +139,9 @@ export function buildAbilitiesContext(draft = {}, classDoc = null) {
   const blocks = abilityKeys.map((key) => {
     const cfg = CONFIG.DND5E.abilities[key];
     const raw = abilityValues[key]?.value;
-    const isEmpty = raw === '' || raw == null;
-    const numericValue = isEmpty ? dflt : Number(raw);
+    const rawEmpty = raw === '' || raw == null;
+    const isEmpty = rawEmpty && method !== 'pointBuy';
+    const numericValue = rawEmpty ? dflt : Number(raw);
     const cost = isEmpty ? 0 : pointBuyCost(numericValue, min);
     if (method === 'pointBuy' && !isEmpty) usedPoints += cost;
     const isPrimary = primary.has(key);
@@ -162,8 +163,8 @@ export function buildAbilitiesContext(draft = {}, classDoc = null) {
       isPrimary,
       primaryTooltip: isPrimary ? _loc('HEROMANCER.App.Abilities.PrimaryTooltip', { ability: _loc(cfg.label), class: className }) : '',
       formulaPlaceholder: customFormula,
-      standardArray: { id: `ability-${key}-sa`, name: `abilities-sa.${key}`, value: isEmpty ? '' : String(raw), placeholder: '—', searchable: false, options: standardArrayUniqueOptions },
-      manualFormulaPool: { id: `ability-${key}-mfp`, name: `abilities-mfp.${key}`, value: isEmpty ? '' : String(raw), placeholder: '—', searchable: false, options: [] }
+      standardArray: { id: `ability-${key}-sa`, name: `abilities-sa.${key}`, value: rawEmpty ? '' : String(raw), placeholder: '—', searchable: false, options: standardArrayUniqueOptions },
+      manualFormulaPool: { id: `ability-${key}-mfp`, name: `abilities-mfp.${key}`, value: rawEmpty ? '' : String(raw), placeholder: '—', searchable: false, options: [] }
     };
   });
   return {

--- a/scripts/domain/advancement-chooser.mjs
+++ b/scripts/domain/advancement-chooser.mjs
@@ -345,10 +345,10 @@ function itemChoiceSpec(adv, level, value, _context) {
     allowDrops: cfg.allowDrops !== false,
     selected: Object.values(value.added ?? {})
   };
-  if (!pool.length && cfg.type) {
+  if (!pool.length && (cfg.type || spec.allowDrops)) {
     const restriction = cfg.restriction ?? {};
     spec.open = true;
-    spec.restrictionType = cfg.type;
+    spec.restrictionType = cfg.type ?? null;
     spec.restrictionCategory = restriction.type || '';
     spec.restrictionSubtype = restriction.subtype || '';
     spec.restrictionLevel = restriction.level ?? '';

--- a/scripts/domain/advancement-chooser.mjs
+++ b/scripts/domain/advancement-chooser.mjs
@@ -121,7 +121,7 @@ function advancementRow(adv, lvl, { origin, draft = {}, context = {} }) {
   const spec = auto ? null : RENDERERS[type](adv, lvl, value, context);
   const grants = type === 'ItemGrant' ? resolveItemGrantEntries(adv) : null;
   const scale = type === 'ScaleValue' ? resolveScaleDelta(adv, lvl) : null;
-  return { advancementId: id, level: lvl, type, title, icon: adv.icon ?? null, spec, auto, origin, grants, scale, source: adv.item?.name ?? null };
+  return { advancementId: id, level: lvl, type, title, icon: adv.icon ?? null, spec, auto, origin, grants, scale, source: adv.item?.name ?? null, parentIdentifier: adv.item?.identifier ?? null };
 }
 
 /** @type {number} Max grant-recursion depth, guarding feat→feat cycles. */

--- a/scripts/domain/advancements-tab.mjs
+++ b/scripts/domain/advancements-tab.mjs
@@ -278,7 +278,16 @@ function itemChoiceTile(row) {
       name: inputName,
       label: row.title || _loc('HEROMANCER.App.Advancements.ChoosePrompt'),
       max: spec.count,
-      optionsJson: JSON.stringify(pickerOptions.map((o) => ({ value: o.value, label: o.label, icon: o.icon ?? null })))
+      optionsJson: JSON.stringify(
+        pickerOptions.map((o) => ({
+          value: o.value,
+          label: o.label,
+          icon: o.icon ?? null,
+          identifier: spec.poolMeta?.[o.value]?.identifier ?? null,
+          reqItems: spec.poolMeta?.[o.value]?.reqItems ?? []
+        }))
+      ),
+      originsJson: spec.originIdentifiers ? JSON.stringify(spec.originIdentifiers) : ''
     };
   }
   return tile;
@@ -698,7 +707,7 @@ function isRowDone(spec) {
 }
 
 /**
- * Drop ItemChoice pool entries failing a level, required-item, or non-repeatable prerequisite, evaluated against the projected post-apply item set. Unresolved entries are kept.
+ * Drop ItemChoice pool entries failing a level or non-repeatable-owned check, retaining item-prerequisite entries for the picker to reveal on selection, and tag each kept entry with its prerequisite metadata.
  * @param {object} row Row record with `spec.kind === 'item-choice'`.
  * @returns {Promise<void>}
  */
@@ -708,20 +717,30 @@ async function filterItemChoicePool(row) {
   const { identifiers, owned } = row.projected ?? { identifiers: new Set(), owned: new Set() };
   const docs = await Promise.all(spec.pool.map((uuid) => fromUuid(uuid)));
   const indexByUuid = new Map(spec.pool.map((uuid, i) => [uuid, i]));
-  const meets = (i) => {
-    const pre = docs[i]?.system?.prerequisites;
-    if (!pre) return true;
-    if (Number.isFinite(Number(pre.level)) && Number(pre.level) > row.level) return false;
-    return !(pre.items?.size && ![...pre.items].some((id) => identifiers.has(leafIdentifier(id))));
+  const reqItemsAt = (i) => {
+    const items = docs[i]?.system?.prerequisites?.items;
+    return items?.size ? [...items].map(leafIdentifier) : [];
   };
-  const kept = new Set((spec.selected ?? []).filter((uuid) => !indexByUuid.has(uuid) || meets(indexByUuid.get(uuid))));
+  const meetsStatic = (i) => {
+    const lvl = docs[i]?.system?.prerequisites?.level;
+    return !(Number.isFinite(Number(lvl)) && Number(lvl) > row.level);
+  };
+  const kept = new Set((spec.selected ?? []).filter((uuid) => !indexByUuid.has(uuid) || meetsStatic(indexByUuid.get(uuid))));
   spec.selected = [...kept];
   spec.pool = spec.pool.filter((uuid, i) => {
     if (kept.has(uuid)) return true;
-    if (!meets(i)) return false;
+    if (!meetsStatic(i)) return false;
     const pre = docs[i]?.system?.prerequisites;
     return !(pre && !pre.repeatable && owned.has(uuid));
   });
+  const selectedIdentifiers = new Set();
+  for (const uuid of spec.selected) {
+    const id = docs[indexByUuid.get(uuid)]?.identifier;
+    if (id) selectedIdentifiers.add(id);
+  }
+  spec.poolMeta = {};
+  for (const uuid of spec.pool) spec.poolMeta[uuid] = { identifier: docs[indexByUuid.get(uuid)]?.identifier ?? null, reqItems: reqItemsAt(indexByUuid.get(uuid)) };
+  spec.originIdentifiers = Object.values(spec.poolMeta).some((m) => m.reqItems.length) ? [...identifiers].filter((id) => !selectedIdentifiers.has(id)) : null;
 }
 
 /**

--- a/scripts/domain/advancements-tab.mjs
+++ b/scripts/domain/advancements-tab.mjs
@@ -732,11 +732,12 @@ async function filterItemChoicePool(row) {
  */
 async function collectProjectedItems(rows, actor) {
   const uuids = new Set();
+  const identifiers = new Set();
   for (const row of rows) {
+    if (row.parentIdentifier) identifiers.add(row.parentIdentifier);
     if (row.type === 'ItemGrant') for (const g of row.grants ?? []) if (g.uuid) uuids.add(g.uuid);
     if (row.spec?.kind === 'item-choice') for (const u of row.spec.selected ?? []) if (u) uuids.add(u);
   }
-  const identifiers = new Set();
   const owned = new Set(uuids);
   for (const item of actor?.items ?? []) {
     if (item.identifier) identifiers.add(item.identifier);

--- a/templates/apps/hero-mancer/tabs/advancements.hbs
+++ b/templates/apps/hero-mancer/tabs/advancements.hbs
@@ -117,7 +117,8 @@
                       data-state="{{tile.state}}" data-foot="{{tile.foot.kind}}" {{#if tile.uuid}}data-item-tooltip
                       data-uuid="{{tile.uuid}}" {{/if}} {{#if tile.picker}} data-picker-trigger
                       data-picker-name="{{tile.picker.name}}" data-picker-label="{{tile.picker.label}}"
-                      data-picker-options="{{tile.picker.optionsJson}}" data-picker-max="{{tile.picker.max}}" {{/if}}
+                      data-picker-options="{{tile.picker.optionsJson}}" data-picker-max="{{tile.picker.max}}"
+                      data-picker-origins="{{tile.picker.originsJson}}" {{/if}}
                       {{#if tile.browse}} data-action="browseAdvancementItems" data-browse="{{tile.browse}}" {{/if}}
                       {{#if tile.selected}}data-selected{{/if}}>
                       {{#if tile.inputName}}

--- a/templates/chat/release-message.hbs
+++ b/templates/chat/release-message.hbs
@@ -6,32 +6,18 @@
 
   <div class="release-body">
     <p class="release-patreon">
-      <strong><a href="{{patreonUrl}}" target="_blank" rel="noopener"><i class="fa-brands fa-patreon"></i> Now on Patreon!</a></strong>
+      <strong><a href="{{patreonUrl}}" target="_blank" rel="noopener"><i class="fa-brands fa-patreon"></i> Now on
+          Patreon!</a></strong>
     </p>
-
-    <h4>New Features</h4>
-    <ul>
-      <li>New GM settings to disable multiclassing and to hide the welcome popup for everyone in the world.</li>
-      <li>Manual hit-die rolls can now be posted to chat automatically.</li>
-      <li>The feat browser can filter by which ability a feat improves, and GMs can exclude specific feats from the picker.</li>
-      <li>Background options now display searchable tags for their ability increase and origin feat.</li>
-      <li>Brazilian Portuguese is now available as a language.</li>
-    </ul>
 
     <h4>Bug Fixes</h4>
     <ul>
-      <li>Granted and chosen feats, including those from ability score improvements, now apply correctly on level up.</li>
-      <li>New characters now start with the right movement, senses, and creature type instead of zero speed.</li>
-      <li>Skill and expertise choices now offer only the right options, and proficiencies you pick during advancement show up in the final review.</li>
-      <li>Equipment that grants multiple picks gives a slot for each, and bundled starting gold is added to your pool.</li>
-      <li>Honor and Sanity abilities are handled correctly throughout creation and level-up.</li>
-      <li>Assorted character creation and level-up interface fixes, including the portrait crop and the duplicate Level Up button.</li>
-    </ul>
-
-    <h4>Changes</h4>
-    <ul>
-      <li>Players are now kept to the GM's chosen art folder when picking character art.</li>
-      <li>Expertise picks now come after the proficiencies they depend on, and the level-up summary whisper option is clearer about who receives it.</li>
+      <li>Advancement picks that let you choose any item now open a compendium browser instead of showing no options.
+      </li>
+      <li>Point Buy ability scores now start at the configured default value instead of blank.</li>
+      <li>Race choices that require your own race, such as the Dragonborn breath weapon, now list their options instead
+        of an error.</li>
+      <li>Tiered heritage traits now reveal their improved version as soon as you pick the base option.</li>
     </ul>
   </div>
 


### PR DESCRIPTION
### Bug Fixes

- [#217] Untyped "choose any item" advancement choices that allow drops, such as Grim Hollow's Rare Find on the Agent of the Augustine background, now open a compendium browser of grantable item types instead of showing "No valid options".
- [#230] Race advancement choices that require the character's own race, such as the Dragonborn Draconic Ancestry breath weapon, now list their valid options instead of showing "No valid options".
- [#231] Tiered item-choice options that require a base option first, such as Grim Hollow heritage traits where Maximum Critical requires Awesome Critical, now appear in the picker the moment you select the base option and cascade-remove when you unselect it, instead of staying hidden until the picker is closed and reopened.
- [#232] Point Buy now seeds each ability score at the configured default value instead of starting blank, with cost, points used, and modifier derived from that default. Standard Array and Manual Formula stay blank.